### PR TITLE
Stop notification_helper and snoretoast from getting shimmed

### DIFF
--- a/Streamlink Twitch GUI/streamlink-twitch-gui.nuspec
+++ b/Streamlink Twitch GUI/streamlink-twitch-gui.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>streamlink-twitch-gui</id>
     <title>Streamlink Twitch GUI</title>
-    <version>1.11.0.20201228</version>
+    <version>1.11.0.20201229</version>
     <authors>Sebastian Meyer</authors>
     <owners>Scott Walters</owners>
     <summary>A multi platform Twitch.tv browser for Streamlink</summary>

--- a/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
+++ b/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
@@ -4,6 +4,9 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 $installDir = Split-Path -parent $toolsDir
 $downloadPath = "https://github.com/streamlink/streamlink-twitch-gui/releases/download/$packageVersion/"
 
+New-Item -ItemType file $installDir\$packageName\notification_helper.exe.ignore -EA 0
+New-Item -ItemType file $installDir\$packageName\bin\win64\snoretoast.exe.ignore -EA 0
+
 Install-ChocolateyZipPackage `
 	-PackageName    $packageName `
 	-Url            "$($downloadPath)streamlink-twitch-gui-$packageVersion-win32.zip" `
@@ -13,9 +16,6 @@ Install-ChocolateyZipPackage `
 	-Checksum64     "D60E6355BDF6B916AD8BFDC0607D79005CC860DA530A3F7129A05D3F7538F294" `
 	-ChecksumType64 "sha256" `
 	-UnzipLocation  $installDir
-
-New-Item -ItemType file $installDir\$packageName\notification_helper.exe.ignore -EA 0
-New-Item -ItemType file $installDir\$packageName\bin\win64\snoretoast.exe.ignore -EA 0
 
 $desktop = [Environment]::GetFolderPath("Desktop")
 $shortcutFile = Join-Path $desktop "$packageName.lnk"

--- a/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
+++ b/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
@@ -14,6 +14,9 @@ Install-ChocolateyZipPackage `
 	-ChecksumType64 "sha256" `
 	-UnzipLocation  $installDir
 
+New-Item -ItemType file $installDir\$packageName\notification_helper.exe.ignore -EA 0
+New-Item -ItemType file $installDir\$packageName\bin\win64\snoretoast.exe.ignore -EA 0
+
 $desktop = [Environment]::GetFolderPath("Desktop")
 $shortcutFile = Join-Path $desktop "$packageName.lnk"
 $exeFile = Join-Path (Join-Path $installDir $packageName) "$packageName.exe"

--- a/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
+++ b/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
@@ -4,8 +4,10 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 $installDir = Split-Path -parent $toolsDir
 $downloadPath = "https://github.com/streamlink/streamlink-twitch-gui/releases/download/$packageVersion/"
 
-New-Item -ItemType file $installDir\$packageName\notification_helper.exe.ignore -EA 0
-New-Item -ItemType file $installDir\$packageName\bin\win64\snoretoast.exe.ignore -EA 0
+New-Item -ItemType file $installDir\$packageName\notification_helper.exe.ignore -EA 0 | Out-Null
+New-Item -ItemType directory $installDir\$packageName\bin\ -EA 0 | Out-Null
+New-Item -ItemType directory $installDir\$packageName\bin\win64\ -EA 0 | Out-Null
+New-Item -ItemType file $installDir\$packageName\bin\win64\snoretoast.exe.ignore -EA 0 | Out-Null
 
 Install-ChocolateyZipPackage `
 	-PackageName    $packageName `

--- a/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
+++ b/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
@@ -4,6 +4,7 @@ $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 $installDir = Split-Path -parent $toolsDir
 $downloadPath = "https://github.com/streamlink/streamlink-twitch-gui/releases/download/$packageVersion/"
 
+New-Item -ItemType directory $installDir\$packageName\ -EA 0 | Out-Null
 New-Item -ItemType file $installDir\$packageName\notification_helper.exe.ignore -EA 0 | Out-Null
 New-Item -ItemType directory $installDir\$packageName\bin\ -EA 0 | Out-Null
 New-Item -ItemType directory $installDir\$packageName\bin\win64\ -EA 0 | Out-Null

--- a/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
+++ b/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
@@ -8,6 +8,8 @@ New-Item -ItemType file $installDir\$packageName\notification_helper.exe.ignore 
 New-Item -ItemType directory $installDir\$packageName\bin\ -EA 0 | Out-Null
 New-Item -ItemType directory $installDir\$packageName\bin\win64\ -EA 0 | Out-Null
 New-Item -ItemType file $installDir\$packageName\bin\win64\snoretoast.exe.ignore -EA 0 | Out-Null
+New-Item -ItemType directory $installDir\$packageName\bin\win32\ -EA 0 | Out-Null
+New-Item -ItemType file $installDir\$packageName\bin\win32\snoretoast.exe.ignore -EA 0 | Out-Null
 
 Install-ChocolateyZipPackage `
 	-PackageName    $packageName `


### PR DESCRIPTION
You have some unnecessary files getting shimmed on install, this PR is here to stop that from happening.