### PR TITLE
Correcting installer version number callout

### DIFF
--- a/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
+++ b/Streamlink Twitch GUI/tools/chocolateyinstall.ps1
@@ -1,5 +1,5 @@
 $packageName = 'streamlink-twitch-gui'
-$packageVersion = 'v1.13.0'
+$packageVersion = 'v2.0.0'
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 $installDir = Split-Path -parent $toolsDir
 $downloadPath = "https://github.com/streamlink/streamlink-twitch-gui/releases/download/$packageVersion/"


### PR DESCRIPTION
In Chocolatey install script packageVersion is incorrectly listed as 1.13.0 when it should be 2.0.0.